### PR TITLE
Add clarification to Red egg readme

### DIFF
--- a/bots/discord/redbot/README.md
+++ b/bots/discord/redbot/README.md
@@ -8,7 +8,7 @@ No port are required to run Red.
 if you want to use the internal Lavalink Server, you need to allocate port 2333 as primary
 
 ### Additional Requirements
-When using the Audio Cog the bot will attempt to save files to /tmp resulting in a disk space error.  To resolve this error you must increase the size of `tmpfs` using custom container policy.
+When using the Audio Cog the bot will attempt to save files to /tmp resulting in a disk space error.  You may also see this same error when attempting to install a cog, due to pip using /tmp to build the requirements.  To resolve this error you must increase the size of `tmpfs` using custom container policy.
 
 For additional details see: 
 https://pterodactyl.io/wings/1.0/configuration.html#other-values


### PR DESCRIPTION
When installing the `defender` cog, and possibly others, you'll get the same disk space error as with using the Audio cog, with the same solution.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Did you branch your changes and PR from that branch and not from your master branch?

### Changes to an existing Egg:

1. [x] Have you added an explanation of what your changes do and why you'd like us to include them?
2. [x] Have you tested your Egg changes?
